### PR TITLE
Update __init__.py

### DIFF
--- a/nonebot_plugin_sticker_saver/__init__.py
+++ b/nonebot_plugin_sticker_saver/__init__.py
@@ -27,7 +27,7 @@ async def handle_face_extraction(bot: Bot, event: MessageEvent):
             if seg.type == "image":
                 content = MessageSegment.text("表情：") + MessageSegment.image(seg.data["url"], type_=0)
                 # 用于 .gif 格式的表情包保存，加上一层跳转防止可能的检测
-                url = str(seg.data["url"]).replace("https://gchat.qpic.cn", TARGET_REDIRECT_URL)
+                url = str(seg.data["url"]).replace("https://gchat.qpic.cn", TARGET_REDIRECT_URL).replace("https://multimedia.nt.qq.com.cn", TARGET_REDIRECT_URL)
                 # async with AsyncClient() as client:
                 #     # @deprecated 用于 .gif 格式的表情包保存，加上一层短链接防止可能的检测
                 #     url = str(seg.data["url"]).replace("https://gchat.qpic.cn", TARGET_REDIRECT_URL)


### PR DESCRIPTION
使用时发现目前很多图片会使用multimedia.nt.qq.com.cn这个域名，根据现有代码，这个域名不会被替换。直接在QQ打开此域名链接时提示风险，不让下载。
于是新增一个域名替换的逻辑。经过测试，域名由multimedia.nt.qq.com.cn替换成pic.colanns.me，再跳转至gchat.qpic.cn，仍然可以正常下载。